### PR TITLE
[CM-1189] add intrinsic content size, rename header view

### DIFF
--- a/Sources/YCalendarPicker/Classes/YCalendarPicker+Appearance.swift
+++ b/Sources/YCalendarPicker/Classes/YCalendarPicker+Appearance.swift
@@ -48,10 +48,10 @@ extension YCalendarPicker {
         ///   - selectedDayAppearance: Appearance for selected day. Default is `.Defaults.selected`.
         ///   - disabledDayAppearance: Appearance for disabled day. Default is `.Defaults.disabled`.
         ///   - bookedDayAppearance: Appearance for already booked day. Default is `Defaults.booked`.
-        ///   - weekdayStyle: Typography and text color for weekdays name. Default is `DefaultStyles.weekday`.
+        ///   - weekdayStyle: Typography and text color for weekday names. Default is `DefaultStyles.weekday`.
         ///   - previousImage: Previous button image. Default is `Appearance.defaultPreviousImage`.
         ///   - nextImage: Next button image. Default is `Appearance.defaultNextImage`.
-        ///   - monthStyle: Typography and text color for Month name in header. Default is `DefaultStyles.month`.
+        ///   - monthStyle: Typography and text color for Month name. Default is `DefaultStyles.month`.
         ///   - backgroundColor: Background color for calendar view. Default is `.systemBackground`.
         public init(
             normalDayAppearance: Day = .Defaults.normal,

--- a/Sources/YCalendarPicker/Classes/YCalendarPicker.swift
+++ b/Sources/YCalendarPicker/Classes/YCalendarPicker.swift
@@ -82,6 +82,37 @@ public class YCalendarPicker: UIControl {
         super.init(coder: coder)
         addCalendarView()
     }
+
+    /// Calculates the intrinsic size of the calendar picker
+    override public var intrinsicContentSize: CGSize {
+        let monthLayout = appearance.monthStyle.typography.generateLayout(
+            maximumScaleFactor: MonthView.maximumScaleFactor,
+            compatibleWith: traitCollection
+        )
+        let weekdayLayout = appearance.weekdayStyle.typography.generateLayout(
+            maximumScaleFactor: WeekdayView.maximumScaleFactor,
+            compatibleWith: traitCollection
+        )
+
+        let daySize = DayView.size.outset(by: NSDirectionalEdgeInsets(all: DayView.padding))
+
+        let width = 7 * daySize.width
+
+        let monthHeight = max(monthLayout.lineHeight, MonthView.minimumButtonSize.height)
+        let weekdayHeight = weekdayLayout.lineHeight + (2 * WeekdayView.verticalPadding)
+        let daysHeight = 6 * daySize.height
+        let height = monthHeight + weekdayHeight + daysHeight
+
+        return CGSize(width: width, height: height)
+    }
+
+    /// Adjusts the intrinsic content size on Dynamic Type changes
+    override public func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if traitCollection.hasDifferentFontAppearance(comparedTo: previousTraitCollection) {
+            invalidateIntrinsicContentSize()
+        }
+    }
 }
 
 private extension YCalendarPicker {

--- a/Sources/YCalendarPicker/Views/DayView.swift
+++ b/Sources/YCalendarPicker/Views/DayView.swift
@@ -10,6 +10,13 @@ import SwiftUI
 import YMatterType
 
 struct DayView {
+    /// maximum scale factor of the month-year text label
+    static let maximumScaleFactor: CGFloat = 1.5
+    /// size of each day
+    static let size = CGSize(width: 40, height: 40)
+    /// horizontal and vertical padding around day view circles
+    static let padding: CGFloat = 2
+
     let appearance: YCalendarPicker.Appearance
     let dateItem: CalendarMonthItem
     let locale: Locale
@@ -27,18 +34,18 @@ extension DayView: View {
             TextStyleLabel(dateItem.day, typography: appearance.typography, configuration: { label in
                 label.isUserInteractionEnabled = true
                 label.textAlignment = .center
-                label.maximumScaleFactor = 1.5
+                label.maximumScaleFactor = DayView.maximumScaleFactor
                 label.textColor = appearance.foregroundColor
             })
-            Spacer().frame(minWidth: 40, minHeight: 40)
+            Spacer().frame(minWidth: DayView.size.width, minHeight: DayView.size.height)
         }
         .background(
             Circle()
                 .stroke(Color(appearance.borderColor), lineWidth: appearance.borderWidth)
                 .background(Circle().foregroundColor(Color(appearance.backgroundColor)))
         )
-        .padding(.horizontal, 2.0)
-        .padding(.vertical, 2.0)
+        .padding(.horizontal, DayView.padding)
+        .padding(.vertical, DayView.padding)
         .onTapGesture {
             guard dateItem.isEnabled else { return }
             selectedDate = dateItem.date

--- a/Sources/YCalendarPicker/Views/MonthView.swift
+++ b/Sources/YCalendarPicker/Views/MonthView.swift
@@ -1,5 +1,5 @@
 //
-//  CalendarHeaderView.swift
+//  MonthView.swift
 //  YCalendarPicker
 //
 //  Created by Sahil Saini on 29/11/22.
@@ -9,11 +9,16 @@
 import SwiftUI
 import YMatterType
 
-/// Calendar header for month and year
-internal struct CalendarHeaderView {
+/// Displays current month and year together with previous and next buttons
+internal struct MonthView {
+    /// maximum scale factor of the month-year text label
+    static let maximumScaleFactor: CGFloat = 1.5
+    /// minimum size for previous and next buttons
+    static let minimumButtonSize = CGSize(width: 44, height: 44)
+
     @Binding var currentDate: Date
     var appearance: YCalendarPicker.Appearance
-    let headerDateFormat: String
+    let dateFormat: String
     let minimumDate: Date?
     let maximumDate: Date?
     let locale: Locale
@@ -38,17 +43,17 @@ internal struct CalendarHeaderView {
     }
 }
 
-extension CalendarHeaderView: View {
+extension MonthView: View {
     var body: some View {
-        getHeader()
+        getMonthView()
     }
     
     @ViewBuilder
-    func getHeader() -> some View {
+    func getMonthView() -> some View {
         HStack {
             TextStyleLabel(getMonthAndYear(), typography: appearance.monthStyle.typography, configuration: { label in
                 label.textColor = appearance.monthStyle.textColor
-                label.maximumScaleFactor = 1.5
+                label.maximumScaleFactor = MonthView.maximumScaleFactor
             })
             
             Spacer()
@@ -61,7 +66,10 @@ extension CalendarHeaderView: View {
                         .foregroundColor(Color(appearance.monthStyle.textColor))
                         .opacity(isPreviousButtonDisabled ? 0.5 : 1.0)
                 })
-                .frame(minWidth: 44, minHeight: 44)
+                .frame(
+                    minWidth: MonthView.minimumButtonSize.width,
+                    minHeight: MonthView.minimumButtonSize.height
+                )
                 .disabled(isPreviousButtonDisabled)
                 .accessibilityLabel(YCalendarPicker.Strings.previousMonthA11yLabel.localized)
                 Button(action: {
@@ -71,7 +79,10 @@ extension CalendarHeaderView: View {
                         .foregroundColor(Color(appearance.monthStyle.textColor))
                         .opacity(isNextButtonDisabled ? 0.5 : 1.0)
                 })
-                .frame(minWidth: 44, minHeight: 44)
+                .frame(
+                    minWidth: MonthView.minimumButtonSize.width,
+                    minHeight: MonthView.minimumButtonSize.height
+                )
                 .disabled(isNextButtonDisabled)
                 .accessibilityLabel(YCalendarPicker.Strings.nextMonthA11yLabel.localized)
             }
@@ -98,16 +109,16 @@ extension CalendarHeaderView: View {
     }
     
     func getMonthAndYear() -> String {
-        currentDate.toString(withTemplate: headerDateFormat, locale: locale) ?? ""
+        currentDate.toString(withTemplate: dateFormat, locale: locale) ?? ""
     }
 }
 
-struct CalendarHeaderView_Previews: PreviewProvider {
+struct MonthView_Previews: PreviewProvider {
     static var previews: some View {
-        CalendarHeaderView(
+        MonthView(
             currentDate: .constant(Date()),
             appearance: .default,
-            headerDateFormat: "MMMMyyyy",
+            dateFormat: "MMMMyyyy",
             minimumDate: nil,
             maximumDate: nil,
             locale: Locale(identifier: "pt_BR")

--- a/Sources/YCalendarPicker/Views/WeekdayView.swift
+++ b/Sources/YCalendarPicker/Views/WeekdayView.swift
@@ -11,7 +11,12 @@ import YMatterType
 
 /// WeekdayView is the view shown for weekday names at top of days/dates
 internal struct WeekdayView {
-    var firstWeekday = 0
+    /// maximum scale factor of the week day text labels
+    static let maximumScaleFactor: CGFloat = 1.33
+    /// vertical padding around week day text labels
+    static let verticalPadding: CGFloat = 2
+
+    var firstWeekday: Int
     var appearance: YCalendarPicker.Appearance
     let weekdayNames: [String]
     
@@ -42,14 +47,14 @@ extension WeekdayView: View {
                 getWeekText(for: index.modulo(7))
             }
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, WeekdayView.verticalPadding)
     }
     
     @ViewBuilder
     func getWeekText(for index: Int) -> some View {
         TextStyleLabel(weekdayNames[index], typography: appearance.weekdayStyle.typography, configuration: { label in
             label.textAlignment = .center
-            label.maximumScaleFactor = 1.33
+            label.maximumScaleFactor = WeekdayView.maximumScaleFactor
             label.textColor = appearance.weekdayStyle.textColor
         })
     }

--- a/Sources/YCalendarPicker/Views/YCalendarView.swift
+++ b/Sources/YCalendarPicker/Views/YCalendarView.swift
@@ -105,9 +105,9 @@ extension YCalendarView: View {
     /// :nodoc:
     public var body: some View {
         VStack(spacing: 0) {
-            getHeader()
+            getMonthView()
             getWeekdayView()
-            getDateView()
+            getDaysView()
         }.gesture(
             DragGesture().onEnded({ value in
                 currentDate = getCurrentDateAfterSwipe(swipeValue: value.translation)
@@ -116,21 +116,24 @@ extension YCalendarView: View {
         .background(Color(self.appearance.backgroundColor))
     }
     
-    /// This function creates a header view
-    /// - Returns: A view with month name, next and previous month button
     @ViewBuilder
-    func getHeader() -> some View {
-        CalendarHeaderView(
+    func getMonthView() -> some View {
+        MonthView(
             currentDate: $currentDate,
             appearance: appearance,
-            headerDateFormat: headerDateFormat,
+            dateFormat: headerDateFormat,
             minimumDate: minimumDate,
             maximumDate: maximumDate,
             locale: locale
         )
     }
-    
-    func getDateView() -> some View {
+
+    @ViewBuilder
+    func getWeekdayView() -> some View {
+        WeekdayView(firstWeekday: firstWeekday, appearance: appearance, locale: locale)
+    }
+
+    func getDaysView() -> some View {
         var allDates = currentDate.getAllDatesForSelectedMonth(firstWeekIndex: firstWeekday.modulo(7))
         allDates = allDates.map { dateItem -> CalendarMonthItem in
             var newItem = dateItem
@@ -160,11 +163,6 @@ extension YCalendarView: View {
         .onChange(of: currentDate) { newValue in
             monthDidChange(newValue.dateOnly)
         }
-    }
-    
-    @ViewBuilder
-    func getWeekdayView() -> some View {
-        WeekdayView(firstWeekday: firstWeekday, appearance: appearance, locale: locale)
     }
 }
 

--- a/Tests/YCalendarPickerTests/Test Helpers/XCTestCase+MemoryLeakTracking.swift
+++ b/Tests/YCalendarPickerTests/Test Helpers/XCTestCase+MemoryLeakTracking.swift
@@ -9,7 +9,7 @@
 import XCTest
 
 extension XCTestCase {
-    func trackForMemoryLeaks(_ instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {
+    func trackForMemoryLeak(_ instance: AnyObject, file: StaticString = #filePath, line: UInt = #line) {
         addTeardownBlock { [weak instance] in
             XCTAssertNil(
                 instance,

--- a/Tests/YCalendarPickerTests/Views/MonthViewTests.swift
+++ b/Tests/YCalendarPickerTests/Views/MonthViewTests.swift
@@ -1,5 +1,5 @@
 //
-//  CalendarHeaderViewTests.swift
+//  MonthViewTests.swift
 //  YCalendarPicker
 //
 //  Created by Sahil Saini on 29/11/22.
@@ -10,14 +10,14 @@ import XCTest
 import SwiftUI
 @testable import YCalendarPicker
 
-final class CalendarHeaderViewTests: XCTestCase {
+final class MonthViewTests: XCTestCase {
     func testMonthAndYearisNotEmpty() {
-        let sut = makeSUT(headerDateFormat: "")
+        let sut = makeSUT(dateFormat: "")
         let monthAndYear = sut.getMonthAndYear()
         XCTAssertNotEqual(monthAndYear, "")
     }
     
-    func testHeaderMonthAndYear() {
+    func testMonthAndYear() {
         let sut = makeSUT()
         let monthAndYear = sut.getMonthAndYear()
         XCTAssertEqual(monthAndYear, Date().toString(withTemplate: "MMMMyyyy"))
@@ -34,14 +34,14 @@ final class CalendarHeaderViewTests: XCTestCase {
         XCTAssertEqual(sut.currentDate, prevExpectedDate2)
     }
     
-    func testHeaderNextImageIsCorrect() {
+    func testNextImageIsCorrect() {
         var sut = makeSUT()
         sut.appearance = YCalendarPicker.Appearance(nextImage: nil)
         let nextImage = sut.getNextImage()
         XCTAssertEqual(nextImage, Image(systemName: "chevron.right").renderingMode(.template))
     }
     
-    func testHeaderPreviousImageIsCorrect() {
+    func testPreviousImageIsCorrect() {
         var sut = makeSUT()
         sut.appearance = YCalendarPicker.Appearance(previousImage: nil)
         let previousImage = sut.getPreviousImage()
@@ -94,28 +94,28 @@ final class CalendarHeaderViewTests: XCTestCase {
         XCTAssertEqual(monthAndYearText, dateFormatter.string(from: Date()))
     }
     
-    func testHeaderPreviewIsNotNill() {
-        XCTAssertNotNil(CalendarHeaderView_Previews.previews)
+    func testPreviewIsNotNill() {
+        XCTAssertNotNil(MonthView_Previews.previews)
     }
 }
 
-private extension CalendarHeaderViewTests {
+private extension MonthViewTests {
     func makeSUT(
         firstWeekday: Int? = nil,
-        headerDateFormat: String? = nil,
+        dateFormat: String? = nil,
         minimumDate: Date? = nil,
         maximumDate: Date? = nil,
         locale: Locale? = nil
-    ) -> CalendarHeaderView {
+    ) -> MonthView {
         var newDate = Date()
         let currentDate = Binding(
             get: { newDate },
             set: { newDate = $0 }
         )
-        let sut = CalendarHeaderView(
+        let sut = MonthView(
             currentDate: currentDate,
             appearance: .default,
-            headerDateFormat: "MMMMyyyy",
+            dateFormat: "MMMMyyyy",
             minimumDate: minimumDate?.dateOnly,
             maximumDate: maximumDate?.dateOnly,
             locale: locale ?? Locale.current

--- a/Tests/YCalendarPickerTests/Views/YCalendarViewTests.swift
+++ b/Tests/YCalendarPickerTests/Views/YCalendarViewTests.swift
@@ -11,16 +11,16 @@ import XCTest
 import SwiftUI
 
 final class YCalendarViewTests: XCTestCase {
-    func testDateViewisNotNil() {
+    func testDaysViewisNotNil() {
         let sut = makeSUT()
-        let dateView = sut.getDateView()
-        XCTAssertNotNil(dateView)
+        let daysView = sut.getDaysView()
+        XCTAssertNotNil(daysView)
     }
     
-    func testCalendarHeaderViewisNotNil() {
+    func testMonthViewisNotNil() {
         let sut = makeSUT()
-        let headerView = sut.getHeader()
-        XCTAssertNotNil(headerView)
+        let monthView = sut.getMonthView()
+        XCTAssertNotNil(monthView)
     }
     
     func testDateBodyisNotNil() {
@@ -189,7 +189,6 @@ final class YCalendarViewTests: XCTestCase {
 private extension YCalendarViewTests {
     func makeSUT(
         firstWeekday: Int? = nil,
-        headerDateFormat: String? = nil,
         minimumDate: Date? = nil,
         maximumDate: Date? = nil
     ) -> YCalendarView {


### PR DESCRIPTION
## Introduction ##

The UIControl subclass YCalendarPicker should have an intrinsic content size.

## Purpose ##

Calculate the size so that the view can properly size itself.
Rename CalendarHeaderView to MonthView
Fixes #3 

## Scope ##

Rename CalendarHeaderView to MonthView
Extract some magic numbers from DayView, WeekdayView, MonthView
Calculate size in YCalendarPicker
Cover two new methods in unit tests

## 🎬 Video ##

GIF showing how the calendar picker (when displayed in a bottom sheet) resizes (just a little) as Dynamic Type is scaled.

![Calendar_picker_CM_1189](https://user-images.githubusercontent.com/1037520/220919687-def9547c-605c-4cb1-b5b5-561bad2c5ae6.gif)

## 📈 Coverage ##

##### Code #####

95.2%

<img width="556" alt="image" src="https://user-images.githubusercontent.com/1037520/220919361-bbef1610-5d05-49c0-9bf1-63c66a7033f3.png">

##### Documentation #####

100%

<img width="806" alt="image" src="https://user-images.githubusercontent.com/1037520/220919532-968e1369-79f0-4bca-a677-d6c3ff2a8c5f.png">