### PR TITLE
[CM-1265] Update read me with dependencies section

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,11 +17,11 @@ let package = Package(
     dependencies: [
         .package(
             url: "https://github.com/yml-org/YCoreUI.git",
-            from: "1.4.0"
+            from: "1.5.0"
         ),
         .package(
             url: "https://github.com/yml-org/YMatterType.git",
-            from: "1.4.0"
+            from: "1.6.0"
         )
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -270,6 +270,11 @@ Our calendar picker also supports Swift UI!
     }
     ```
 
+Dependencies
+----------
+
+Y—CalendarPicker depends upon our [Y—CoreUI](https://github.com/yml-org/ycoreui) and [Y—MatterType](https://github.com/yml-org/ymattertype) frameworks (both also open source and Apache 2.0 licensed).
+
 Installation
 ----------
 


### PR DESCRIPTION
## Introduction ##

Update read me with dependencies section.
## Purpose ##

Read me file is updated with dependencies section. We have two dependencies for Y-CalendarPicker, YCoreUI and YMatterType.

Package file is also updated to match with latest dependency versions; YCoreUI - 1.5.0, YMatterType - 1.6.0.

Fix https://github.com/yml-org/ycalendarpicker-ios/issues/7
## Scope ##

Read me file and package file for dependencies.
## Out of Scope ##

Any functionality or UI changes as only readme and package versions are updated.

## 📈 Coverage ##

##### Code #####

No change in code coverage as only read me and package file is updated.
##### Documentation #####

No change in public APIs. Only readme and package file is updated.