### PR TITLE
[CM-1503] added hidden functionality for day view

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ public struct Day {
     public var borderColor: UIColor
     /// Border width for day view
     public var borderWidth: CGFloat
+    /// Hides day view (if true)
+    public var isHidden: Bool
 }
 ```
 

--- a/Sources/YCalendarPicker/Model/CalendarMonthItem+DayAppearance.swift
+++ b/Sources/YCalendarPicker/Model/CalendarMonthItem+DayAppearance.swift
@@ -13,6 +13,9 @@ extension CalendarMonthItem {
         if isBooked {
             return appearance.bookedDayAppearance
         } else if !isEnabled {
+            if isGrayedOut {
+                return appearance.grayedDayAppearance
+            }
             return appearance.disabledDayAppearance
         } else if isSelected {
             return appearance.selectedDayAppearance

--- a/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
@@ -212,7 +212,30 @@ extension CalendarView {
     
     func getCurrentDateAfterSwipe(swipeValue: CGSize) -> Date {
         let monthCount = (swipeValue.width > 0) ? -1 : 1
-        
+
+        var isNextButtonDisabled: Bool {
+            guard let expectedDate = currentDate.date(byAddingMonth: 1)?.dateOnly else { return true }
+            if let maxDate = maximumDate, expectedDate > maxDate {
+                return true
+            }
+            return false
+        }
+
+        var isPreviousButtonDisabled: Bool {
+            // -7 as max days from previous month can be 7.
+            // current date is first of every month
+            guard let expectedDate = currentDate.date(byAddingDays: -7)?.dateOnly else { return true }
+
+            if let minDate = minimumDate, expectedDate < minDate {
+                return true
+            }
+            return false
+        }
+
+        if (monthCount == -1 && isPreviousButtonDisabled) || (monthCount == 1 && isNextButtonDisabled) {
+            return currentDate
+        }
+
         return currentDate.date(byAddingMonth: monthCount)?.dateOnly ?? currentDate
     }
     

--- a/Sources/YCalendarPicker/SwiftUI/Views/DayView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/DayView.swift
@@ -47,7 +47,8 @@ extension DayView: View {
         .padding(.horizontal, DayView.padding)
         .padding(.vertical, DayView.padding)
         .onTapGesture {
-            guard dateItem.isEnabled, appearance.isHidden else { return }
+            guard !appearance.isHidden else { return }
+            guard dateItem.isEnabled else { return }
             selectedDate = dateItem.date
         }
         .accessibilityAddTraits(getAccessibilityTraits())

--- a/Sources/YCalendarPicker/SwiftUI/Views/DayView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/DayView.swift
@@ -47,7 +47,7 @@ extension DayView: View {
         .padding(.horizontal, DayView.padding)
         .padding(.vertical, DayView.padding)
         .onTapGesture {
-            guard dateItem.isEnabled else { return }
+            guard dateItem.isEnabled, appearance.isHidden else { return }
             selectedDate = dateItem.date
         }
         .accessibilityAddTraits(getAccessibilityTraits())

--- a/Sources/YCalendarPicker/UIKit/CalendarPicker+Appearance+Day.swift
+++ b/Sources/YCalendarPicker/UIKit/CalendarPicker+Appearance+Day.swift
@@ -22,6 +22,8 @@ extension CalendarPicker.Appearance {
         public var borderColor: UIColor
         /// Border width for day view
         public var borderWidth: CGFloat
+        /// Hides day view (if true)
+        public var isHidden: Bool
         
         /// Initializes a calendar day appearance
         /// - Parameters:
@@ -30,18 +32,26 @@ extension CalendarPicker.Appearance {
         ///   - backgroundColor: Background color for day view. Default is `.clear`.
         ///   - borderColor: Border color for day view. Default is `.clear`.
         ///   - borderWidth: Border width for day view. Default is `1.0`.
+        ///   - isHidden: Hides day(s). Default is `false`.
         public init(
             typography: Typography = .day,
             foregroundColor: UIColor = .label,
             backgroundColor: UIColor = .clear,
             borderColor: UIColor = .clear,
-            borderWidth: CGFloat = 1.0
+            borderWidth: CGFloat = 1.0,
+            isHidden: Bool = false
         ) {
-            self.typography = typography
-            self.foregroundColor = foregroundColor
-            self.backgroundColor = backgroundColor
-            self.borderColor = borderColor
-            self.borderWidth = borderWidth
+            if isHidden {
+                self = Defaults.hidden
+                self.isHidden = isHidden
+            } else {
+                self.typography = typography
+                self.foregroundColor = foregroundColor
+                self.backgroundColor = backgroundColor
+                self.borderColor = borderColor
+                self.borderWidth = borderWidth
+                self.isHidden = isHidden
+            }
         }
     }
 }
@@ -73,6 +83,12 @@ extension CalendarPicker.Appearance.Day {
         public static let selected = CalendarPicker.Appearance.Day(
             foregroundColor: CalendarPicker.Appearance.onTintColor,
             backgroundColor: CalendarPicker.Appearance.tintColor
+        )
+
+        /// Default appearance for hidden day
+        public static let hidden = CalendarPicker.Appearance.Day(
+            foregroundColor: .clear,
+            backgroundColor: .clear
         )
     }
 }

--- a/Tests/YCalendarPickerTests/UIKit/CalendarPickerAppearanceDayTests.swift
+++ b/Tests/YCalendarPickerTests/UIKit/CalendarPickerAppearanceDayTests.swift
@@ -27,4 +27,13 @@ final class CalendarPickerAppearanceDayTests: XCTestCase {
         XCTAssertEqual(sut.borderColor, UIColor.clear)
         XCTAssertEqual(sut.borderWidth, 1.0)
     }
+
+    func testHiddenAppearance() {
+        let sut = CalendarPicker.Appearance.Day(isHidden: true)
+        XCTAssertTypographyEqual(sut.typography, .day)
+        XCTAssertEqual(sut.foregroundColor, UIColor.clear)
+        XCTAssertEqual(sut.backgroundColor, UIColor.clear)
+        XCTAssertEqual(sut.borderColor, UIColor.clear)
+        XCTAssertEqual(sut.borderWidth, 1.0)
+    }
 }


### PR DESCRIPTION
## Introduction ##

Add hide functionality for day view.
## Purpose ##

User should be able to hide a type of day(s) in the calendar.
Added - https://github.com/yml-org/ycalendarpicker-ios/issues/13
## Scope ##

Appearance of Day view. (Hide/show)

## 📈 Coverage ##

##### Code #####

~95% code coverage.
<img width="1285" alt="code" src="https://github.com/yml-org/ycalendarpicker-ios/assets/111066844/a814660c-f36b-4d6b-a6ff-b9195c3e39ab">

##### Documentation #####

100% documentation coverage.
<img width="566" alt="Doc" src="https://github.com/yml-org/ycalendarpicker-ios/assets/111066844/5be52f20-1715-4786-b525-861f505b8dc4">
