### PR TITLE
[CM-1516] Added date with time extension to date

### DIFF
--- a/Sources/YCalendarPicker/Extensions/Date+dateWithTime.swift
+++ b/Sources/YCalendarPicker/Extensions/Date+dateWithTime.swift
@@ -1,0 +1,22 @@
+//
+//  Date+dateWithTime.swift
+//  YCalendarPicker
+//
+//  Created by Sahil Saini on 27/07/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import Foundation
+/// Add `dateWithTime` computed property
+extension Date {
+    /// Returns a new `Date` representing the date calculated by setting hour, minute, and second
+    /// to current values on a specified `Date` using the local time zone.
+    public var dateWithTime: Date? {
+        let currentDate = Date()
+        let hours = Calendar.current.component(.hour, from: currentDate)
+        let minutes = Calendar.current.component(.minute, from: currentDate)
+        let seconds = Calendar.current.component(.second, from: currentDate)
+
+        return Calendar.current.date(bySettingHour: hours, minute: minutes, second: seconds, of: self)
+    }
+}

--- a/Tests/YCalendarPickerTests/Extensions/Date+dateWithTime.swift
+++ b/Tests/YCalendarPickerTests/Extensions/Date+dateWithTime.swift
@@ -1,0 +1,52 @@
+//
+//  Date+dateWithTime.swift
+//  YCalendarPicker
+//
+//  Created by Sahil Saini on 27/07/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+import YCalendarPicker
+
+final class DateWithTime: XCTestCase {
+    func testDateWithTimeHasCorrectDate() throws {
+        let date = try XCTUnwrap(makeDate())
+        guard let sut = date.dateWithTime else {
+            XCTFail("Unable to get date with time")
+            return
+        }
+
+        let comp1 = Calendar.current.dateComponents([.year, .month, .day], from: date)
+        let comp2 = Calendar.current.dateComponents([.year, .month, .day], from: sut)
+
+        XCTAssertEqual(comp1.year, comp2.year)
+        XCTAssertEqual(comp1.month, comp2.month)
+        XCTAssertEqual(comp1.day, comp2.day)
+    }
+
+    func testDateOnlyHasNoTime() throws {
+        let date = try XCTUnwrap(makeDate())
+        guard let sut = date.dateWithTime else {
+            XCTFail("Unable to get date with time")
+            return
+        }
+        let timeDate = Date()
+
+        let components = Calendar.current.dateComponents([.hour, .minute, .second, .nanosecond], from: sut)
+        let expectedComponents = Calendar.current.dateComponents([.hour, .minute, .second, .nanosecond], from: timeDate)
+
+        XCTAssertEqual(components.hour, expectedComponents.hour)
+        XCTAssertEqual(components.minute, expectedComponents.minute)
+        XCTAssertEqual(components.second, expectedComponents.second)
+        XCTAssertEqual(components.nanosecond, 0)
+    }
+}
+
+private extension DateWithTime {
+    func makeDate() -> Date? {
+        Date()
+            .date(byAddingMonth: Int.random(in: -6...6))?
+            .date(byAddingDays: Int.random(in: -15...15))
+    }
+}


### PR DESCRIPTION
## Introduction ##

Add new method to date to get current time with selected date.
## Purpose ##

A new method is added to the date extension to support dateWithTime; time associated with the date will be the time when the property is accessed.
## Scope ##

Date only.
## Out of Scope ##

Any functionality or UI change except date extension.

## 📈 Coverage ##

##### Code #####

~95%
<img width="1268" alt="Coverage" src="https://github.com/yml-org/ycalendarpicker-ios/assets/111066844/4b1d4d0a-c5e1-4566-a789-0ac81bfe9446">


##### Documentation #####
100% 
<img width="568" alt="Documetation" src="https://github.com/yml-org/ycalendarpicker-ios/assets/111066844/3b5019a0-5b34-4c45-8f0b-977f53ec785d">
