### PR TITLE
[CM-1522] Added preceding minimum date

### DIFF
--- a/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
@@ -222,6 +222,9 @@ extension CalendarView {
         }
 
         var isPreviousButtonDisabled: Bool {
+            if appearance.allowPrecedeMinimumDate {
+                return false
+            }
             // -7 as max days from previous month can be 7.
             // current date is first of every month
             guard let expectedDate = currentDate.date(byAddingDays: -7)?.dateOnly else { return true }

--- a/Sources/YCalendarPicker/SwiftUI/Views/MonthView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/MonthView.swift
@@ -32,6 +32,9 @@ internal struct MonthView {
     }
     
     var isPreviousButtonDisabled: Bool {
+        if appearance.allowPrecedeMinimumDate {
+            return false
+        }
         // -7 as max days from previous month can be 7.
         // current date is first of every month
         guard let expectedDate = currentDate.date(byAddingDays: -7)?.dateOnly else { return true }

--- a/Sources/YCalendarPicker/UIKit/CalendarPicker+Appearance.swift
+++ b/Sources/YCalendarPicker/UIKit/CalendarPicker+Appearance.swift
@@ -39,7 +39,9 @@ extension CalendarPicker {
         public var monthStyle: (textColor: UIColor, typography: Typography)
         /// Background color for calendar view
         public var backgroundColor: UIColor
-        
+        /// Enable preceding to minimum date.
+        public var allowPrecedeMinimumDate: Bool
+
         /// Initializes a calendar appearance.
         /// - Parameters:
         ///   - normalDayAppearance: Appearance for days within current month. Default is `.Defaults.normal`.
@@ -53,6 +55,8 @@ extension CalendarPicker {
         ///   - nextImage: Next button image. Default is `Appearance.defaultNextImage`.
         ///   - monthStyle: Typography and text color for Month name. Default is `DefaultStyles.month`.
         ///   - backgroundColor: Background color for calendar view. Default is `.systemBackground`.
+        ///   - allowPrecedeMinimumDate: Enable preceding to minimum date. Default is `false`.
+
         public init(
             normalDayAppearance: Day = .Defaults.normal,
             grayedDayAppearance: Day = .Defaults.grayed,
@@ -64,7 +68,8 @@ extension CalendarPicker {
             previousImage: UIImage? = Appearance.defaultPreviousImage,
             nextImage: UIImage? = Appearance.defaultNextImage,
             monthStyle: (textColor: UIColor, typography: Typography) = DefaultStyles.month,
-            backgroundColor: UIColor = .systemBackground
+            backgroundColor: UIColor = .systemBackground,
+            allowPrecedeMinimumDate: Bool = false
         ) {
             self.normalDayAppearance = normalDayAppearance
             self.grayedDayAppearance = grayedDayAppearance
@@ -77,6 +82,7 @@ extension CalendarPicker {
             self.nextImage = nextImage
             self.monthStyle = monthStyle
             self.backgroundColor = backgroundColor
+            self.allowPrecedeMinimumDate = allowPrecedeMinimumDate
         }
     }
 }

--- a/Tests/YCalendarPickerTests/UIKit/CalendarPickerTests.swift
+++ b/Tests/YCalendarPickerTests/UIKit/CalendarPickerTests.swift
@@ -64,7 +64,34 @@ final class CalendarPickerTests: XCTestCase {
         sut.date = selectedDate
         XCTAssertEqual(sut.date, selectedDate.dateOnly)
     }
-    
+
+    func testCalendarPickerPrecedeMinDate() throws {
+        let minDate = Date().previousDate()
+        let sut = makeSUT(minDate: minDate)
+
+        var monthView = try XCTUnwrap(sut.calendarView.getMonthView() as? MonthView)
+
+        XCTAssertTrue(monthView.isPreviousButtonDisabled)
+
+        XCTAssertEqual(
+            sut.calendarView.currentDate,
+            sut.calendarView.getCurrentDateAfterSwipe(
+                swipeValue: CGSize(width: 10, height: 10)
+            )
+        )
+
+        sut.appearance.allowPrecedeMinimumDate = true
+        monthView = try XCTUnwrap(sut.calendarView.getMonthView() as? MonthView)
+        XCTAssertFalse(monthView.isPreviousButtonDisabled)
+
+        XCTAssertNotEqual(
+            sut.calendarView.currentDate,
+            sut.calendarView.getCurrentDateAfterSwipe(
+                swipeValue: CGSize(width: 10, height: 10)
+            )
+        )
+    }
+
     func testCalendarPickerIsNotNilForOptionalInit() {
         XCTAssertNotNil(makeSUTWithFailable())
     }


### PR DESCRIPTION
## Introduction ##

User should be able to move to preceding dates then minimum date.
## Purpose ##

Allow user to go to preceding date to minimum date if there is a minimum date.
## Scope ##

Preceding date from minimum date should be visible to user. It will make previous month button enable.

## Out of Scope ##

Basic UI will remain same other then previous button is now enable.
## 📈 Coverage ##

##### Code #####

~95% code coverage.
<img width="1087" alt="Coverage" src="https://github.com/yml-org/ycalendarpicker-ios/assets/111066844/2a360491-533f-4561-9917-f5b462f047de">

##### Documentation #####

100% documentation.
<img width="413" alt="Documentation" src="https://github.com/yml-org/ycalendarpicker-ios/assets/111066844/57af59cd-3fd9-404b-8534-d92982fc8a66">
