### PR TITLE
[CM-1523] Booked date hide from view if date is in next or previous month

### DIFF
--- a/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
@@ -161,7 +161,8 @@ extension CalendarView: View {
             allDates: allDates,
             appearance: appearance,
             selectedDate: selectedDate,
-            locale: locale
+            locale: locale,
+            currentDate: currentDate
         )
         .onChange(of: date) { newValue in
             selectedDateDidChange(newValue?.dateOnly)

--- a/Sources/YCalendarPicker/SwiftUI/Views/DayView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/DayView.swift
@@ -17,7 +17,7 @@ struct DayView {
     /// horizontal and vertical padding around day view circles
     static let padding: CGFloat = 2
 
-    let appearance: CalendarPicker.Appearance
+    let appearance: CalendarPicker.Appearance.Day
     let dateItem: CalendarMonthItem
     let locale: Locale
     @Binding var selectedDate: Date?
@@ -25,11 +25,10 @@ struct DayView {
 
 extension DayView: View {
     var body: some View {
-        let appearance = getDayAppearance()
-        getDayView(appearance: appearance)
+        getDayView()
     }
     
-    func getDayView(appearance: CalendarPicker.Appearance.Day) -> some View {
+    func getDayView() -> some View {
         ZStack {
             TextStyleLabel(dateItem.day, typography: appearance.typography, configuration: { label in
                 label.isUserInteractionEnabled = true
@@ -85,10 +84,6 @@ extension DayView: View {
         
         return CalendarPicker.Strings.dayButtonA11yHint.localized
     }
-
-    func getDayAppearance() -> CalendarPicker.Appearance.Day {
-        dateItem.getDayAppearance(from: appearance)
-    }
 }
 
 struct DayView_Previews: PreviewProvider {
@@ -107,13 +102,44 @@ struct DayView_Previews: PreviewProvider {
         let item4 = tomorrow.toCalendarItem(isSelected: true)
         let item5 = dayAfter.toCalendarItem(isBooked: true)
         let item6 = later.toCalendarItem(isEnabled: false)
+        let appearance = CalendarPicker.Appearance()
         HStack {
-            DayView(appearance: .default, dateItem: item1, locale: locale, selectedDate: .constant(Date()))
-            DayView(appearance: .default, dateItem: item2, locale: locale, selectedDate: .constant(Date()))
-            DayView(appearance: .default, dateItem: item3, locale: locale, selectedDate: .constant(Date()))
-            DayView(appearance: .default, dateItem: item4, locale: locale, selectedDate: .constant(Date()))
-            DayView(appearance: .default, dateItem: item5, locale: locale, selectedDate: .constant(Date()))
-            DayView(appearance: .default, dateItem: item6, locale: locale, selectedDate: .constant(Date()))
+            DayView(
+                appearance: appearance.grayedDayAppearance,
+                dateItem: item1,
+                locale: locale,
+                selectedDate: .constant(Date())
+            )
+            DayView(
+                appearance: appearance.normalDayAppearance,
+                dateItem: item2,
+                locale: locale,
+                selectedDate: .constant(Date())
+            )
+            DayView(
+                appearance: appearance.todayAppearance,
+                dateItem: item3,
+                locale: locale,
+                selectedDate: .constant(Date())
+            )
+            DayView(
+                appearance: appearance.selectedDayAppearance,
+                dateItem: item4,
+                locale: locale,
+                selectedDate: .constant(Date())
+            )
+            DayView(
+                appearance: appearance.bookedDayAppearance,
+                dateItem: item5,
+                locale: locale,
+                selectedDate: .constant(Date())
+            )
+            DayView(
+                appearance: appearance.disabledDayAppearance,
+                dateItem: item6,
+                locale: locale,
+                selectedDate: .constant(Date())
+            )
         }
         .padding(.horizontal, 16)
     }

--- a/Sources/YCalendarPicker/SwiftUI/Views/DaysView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/DaysView.swift
@@ -14,6 +14,7 @@ internal struct DaysView {
     var appearance: CalendarPicker.Appearance
     @Binding var selectedDate: Date?
     let locale: Locale
+    let currentDate: Date
 }
 
 extension DaysView: View {
@@ -33,8 +34,12 @@ extension DaysView: View {
     func getDay(index: Int) -> some View {
         var dateItem = allDates[index]
         dateItem.isSelected = dateItem.date == selectedDate
+        var dayAppearance = dateItem.getDayAppearance(from: appearance)
+        if dateItem.isBooked && !dateItem.date.isSameMonth(as: currentDate) {
+            dayAppearance = appearance.grayedDayAppearance
+        }
         let dayView = DayView(
-            appearance: appearance,
+            appearance: dayAppearance,
             dateItem: dateItem,
             locale: locale,
             selectedDate: $selectedDate
@@ -49,7 +54,8 @@ struct DaysView_Previews: PreviewProvider {
             allDates: Date().getAllDatesForSelectedMonth(firstWeekIndex: 0),
             appearance: .default,
             selectedDate: .constant(Date()),
-            locale: Locale(identifier: "de_DE")
+            locale: Locale(identifier: "de_DE"),
+            currentDate: Date()
         )
         .padding(.horizontal, 16)
     }

--- a/Tests/YCalendarPickerTests/Extensions/CalendarMonthItem+appearance.swift
+++ b/Tests/YCalendarPickerTests/Extensions/CalendarMonthItem+appearance.swift
@@ -1,0 +1,73 @@
+//
+//  CalendarMonthItemAppearance.swift
+//  YCalendarTest
+//
+//  Created by Sahil Saini on 18/08/23.
+//  Copyright © 2023 Y Media Labs. All rights reserved.
+//
+
+import XCTest
+@testable import YCalendarPicker
+
+final class CalendarMonthItemAppearance: XCTestCase {
+    func testDateTextAppearanceForSelectedDate() {
+        let sut = makeSUT(isSelected: true)
+        XCTAssertAppearanceEqual(appearance1: sut, appearance2: .Defaults.selected)
+    }
+
+    func testDateTextAppearanceForToday() {
+        let sut = makeSUT(isToday: true)
+        XCTAssertAppearanceEqual(appearance1: sut, appearance2: .Defaults.today)
+    }
+
+    func testDateTextAppearanceForBookedDate() {
+        let sut = makeSUT(isBooked: true)
+        XCTAssertAppearanceEqual(appearance1: sut, appearance2: .Defaults.booked)
+    }
+
+    func testDateTextAppearanceForGrayedDate() {
+        let sut = makeSUT(isGrayedOut: true, dateToTest: Date().previousDate())
+        XCTAssertAppearanceEqual(appearance1: sut, appearance2: .Defaults.grayed)
+    }
+
+    func testDateTextAppearanceForDisabledGrayedDate() {
+        let sut = makeSUT(isGrayedOut: true, isEnabled: false, dateToTest: Date().previousDate())
+        XCTAssertAppearanceEqual(appearance1: sut, appearance2: .Defaults.grayed)
+    }
+
+    func testDateTextAppearanceForDisabledDate() {
+        let sut = makeSUT(isEnabled: false, dateToTest: Date().previousDate())
+        XCTAssertAppearanceEqual(appearance1: sut, appearance2: .Defaults.disabled)
+    }
+}
+
+extension CalendarMonthItemAppearance {
+    func makeSUT(
+        isToday: Bool = false,
+        isGrayedOut: Bool = false,
+        isSelected: Bool = false,
+        isEnabled: Bool = true,
+        dateToTest: Date = Date(),
+        isBooked: Bool = false
+    ) -> CalendarPicker.Appearance.Day {
+        let dateItem = dateToTest.toCalendarItem(
+            isGrayedOut: isGrayedOut,
+            isSelected: isSelected,
+            isEnabled: isEnabled,
+            isBooked: isBooked
+        )
+
+        return dateItem.getDayAppearance(from: .default)
+    }
+
+    func XCTAssertAppearanceEqual(
+        appearance1: CalendarPicker.Appearance.Day,
+        appearance2: CalendarPicker.Appearance.Day
+    ) {
+        XCTAssertTypographyEqual(appearance1.typography, appearance2.typography)
+        XCTAssertEqual(appearance1.borderWidth, appearance2.borderWidth)
+        XCTAssertEqual(appearance1.borderColor, appearance2.borderColor)
+        XCTAssertEqual(appearance1.backgroundColor, appearance2.backgroundColor)
+        XCTAssertEqual(appearance1.foregroundColor, appearance2.foregroundColor)
+    }
+}

--- a/Tests/YCalendarPickerTests/SwiftUI/DayViewTests.swift
+++ b/Tests/YCalendarPickerTests/SwiftUI/DayViewTests.swift
@@ -18,37 +18,36 @@ final class DayViewTests: XCTestCase {
     }
 
     func testDateTextAppearanceForSelectedDate() {
-        let sut = makeSUT(isSelected: true)
-        let selectedAppearance = sut.getDayAppearance()
-        XCTAssertAppearanceEqual(appearance1: selectedAppearance, appearance2: .Defaults.selected)
+        let sut = makeSUT(isSelected: true, appearance: .Defaults.selected)
+        XCTAssertAppearanceEqual(appearance1: sut.appearance, appearance2: .Defaults.selected)
     }
 
     func testDateTextAppearanceForToday() {
-        let sut = makeSUT()
-        XCTAssertAppearanceEqual(appearance1: sut.getDayAppearance(), appearance2: .Defaults.today)
+        let sut = makeSUT(appearance: .Defaults.today)
+        XCTAssertAppearanceEqual(appearance1: sut.appearance, appearance2: .Defaults.today)
     }
 
     func testDateTextAppearanceForCurrentMonth() {
         let previousDate = Date().previousDate()
-        let sut = makeSUT(dateToTest: previousDate)
-        XCTAssertAppearanceEqual(appearance1: sut.getDayAppearance(), appearance2: .Defaults.normal)
+        let sut = makeSUT(dateToTest: previousDate, appearance: .Defaults.normal)
+        XCTAssertAppearanceEqual(appearance1: sut.appearance, appearance2: .Defaults.normal)
     }
     
     func testDateTextAppearanceForGrayOutDate() throws {
         let previousMonthDate = try XCTUnwrap(Calendar.current.date(byAdding: .month, value: -1, to: Date()))
-        let sut = makeSUT(isGrayedOut: true, dateToTest: previousMonthDate)
-        XCTAssertAppearanceEqual(appearance1: sut.getDayAppearance(), appearance2: .Defaults.grayed)
+        let sut = makeSUT(isGrayedOut: true, dateToTest: previousMonthDate, appearance: .Defaults.grayed)
+        XCTAssertAppearanceEqual(appearance1: sut.appearance, appearance2: .Defaults.grayed)
     }
     
     func testDateTextAppearanceForNotEnabledDate() throws {
         let previousMonthDate = try XCTUnwrap(Calendar.current.date(byAdding: .month, value: -1, to: Date()))
-        let sut = makeSUT(isEnabled: false, dateToTest: previousMonthDate)
-        XCTAssertAppearanceEqual(appearance1: sut.getDayAppearance(), appearance2: .Defaults.disabled)
+        let sut = makeSUT(isEnabled: false, dateToTest: previousMonthDate, appearance: .Defaults.disabled)
+        XCTAssertAppearanceEqual(appearance1: sut.appearance, appearance2: .Defaults.disabled)
     }
     
     func testDateTextAppearanceForBookedDates() {
-        let sut = makeSUT(isBooked: true)
-        XCTAssertAppearanceEqual(appearance1: sut.getDayAppearance(), appearance2: .Defaults.booked)
+        let sut = makeSUT(isBooked: true, appearance: .Defaults.booked)
+        XCTAssertAppearanceEqual(appearance1: sut.appearance, appearance2: .Defaults.booked)
     }
     
     func testDateBodyPreviewisNotNil() {
@@ -93,7 +92,8 @@ private extension DayViewTests {
         isEnabled: Bool = true,
         dateToTest: Date = Date(),
         locale: Locale? = nil,
-        isBooked: Bool = false
+        isBooked: Bool = false,
+        appearance: CalendarPicker.Appearance.Day = .Defaults.normal
     ) -> DayView {
         let dateItem = dateToTest.toCalendarItem(
             isGrayedOut: isGrayedOut,
@@ -102,7 +102,7 @@ private extension DayViewTests {
             isBooked: isBooked
         )
         let sut = DayView(
-            appearance: .default,
+            appearance: appearance,
             dateItem: dateItem,
             locale: locale ?? Locale.current,
             selectedDate: .constant(Date())

--- a/Tests/YCalendarPickerTests/SwiftUI/DaysViewTests.swift
+++ b/Tests/YCalendarPickerTests/SwiftUI/DaysViewTests.swift
@@ -39,7 +39,8 @@ private extension DaysViewTests {
             allDates: allDates,
             appearance: .default,
             selectedDate: .constant(Date()),
-            locale: Locale.current
+            locale: Locale.current,
+            currentDate: Date()
         )
         XCTAssertNotNil(sut.body)
         return sut


### PR DESCRIPTION
## Introduction ##

Don't show booked date if the date falls in next or previous month.
## Purpose ##

Right now user is able to see booked date even if its not in current month view. 

## 📈 Coverage ##

##### Code #####

~95% code coverage.

<img width="1088" alt="Coverage" src="https://github.com/yml-org/ycalendarpicker-ios/assets/111066844/ace88f90-b1ee-41c8-abb9-471585d24e3e">

##### Documentation #####

100%
<img width="568" alt="Documentation" src="https://github.com/yml-org/ycalendarpicker-ios/assets/111066844/5b9b5151-560b-46e1-8c50-1d22a5baedce">

