### PR TITLE
[CM-1527] only current month's date are shown

### DIFF
--- a/Sources/YCalendarPicker/SwiftUI/Views/DaysView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/DaysView.swift
@@ -35,7 +35,7 @@ extension DaysView: View {
         var dateItem = allDates[index]
         dateItem.isSelected = dateItem.date == selectedDate
         var dayAppearance = dateItem.getDayAppearance(from: appearance)
-        if dateItem.isBooked && !dateItem.date.isSameMonth(as: currentDate) {
+        if !dateItem.date.isSameMonth(as: currentDate) {
             dayAppearance = appearance.grayedDayAppearance
         }
         let dayView = DayView(


### PR DESCRIPTION
## Introduction ##

Only current month's date should be visible even if those are selected or booked dates.
## Purpose ##

Currently selected date is visible even if it's falling in previous or next month. Expected behaviour is only current month's date should be visible.

<img width="540" alt="coverage" src="https://github.com/yml-org/ycalendarpicker-ios/assets/111066844/ec499606-0bc7-4bc8-8c01-1a87d8f34d11">

## Out of Scope ##

Any UI changes are out of scope.

## 📈 Coverage ##

##### Code #####

95% code coverage.
<img width="782" alt="coverage" src="https://github.com/yml-org/ycalendarpicker-ios/assets/111066844/9f7a596d-7d81-44f6-951f-ced4bf2832ce">


##### Documentation #####

No change in documentation.