### PR TITLE
test case updated

### DIFF
--- a/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
+++ b/Sources/YCalendarPicker/SwiftUI/Views/CalendarView.swift
@@ -109,7 +109,7 @@ public struct CalendarView {
         self.minimumDate = minimumDate?.dateOnly
         self.maximumDate = maximumDate?.dateOnly
         self.locale = locale ?? Locale.current
-        self.startDate = startDate
+        self.startDate = startDate?.startDateOfMonth()
     }
 }
 

--- a/Tests/YCalendarPickerTests/SwiftUI/CalendarViewTests.swift
+++ b/Tests/YCalendarPickerTests/SwiftUI/CalendarViewTests.swift
@@ -178,9 +178,10 @@ final class CalendarViewTests: XCTestCase {
     }
     
     func testOnStartDate() {
-        let sut = makeSUT(startDate: Date().date(byAddingMonth: 4))
+        let expectedDate = Date().date(byAddingMonth: 4)
+        let sut = makeSUT(startDate: expectedDate)
         XCTAssertNotNil(sut.startDate)
-        XCTAssertNotEqual(sut.currentDate, sut.startDate)
+        XCTAssertEqual(expectedDate?.startDateOfMonth(), sut.startDate)
     }
     
     func testCalendarViewPreviewIsNotNill() {


### PR DESCRIPTION
## Introduction ##
Show Date month 

## Purpose ##
- We should allow a user to show the given date month.
- Test case updated against the )PR-22)

## Scope ##

we have introduced a new property startDate in which user can add the date and will show the given date month on calendar.

## 📈 Coverage ##

##### Code #####
<img width="1391" alt="Screenshot 2023-12-11 at 5 10 45 PM" src="https://github.com/codeandtheory/ycalendarpicker-ios/assets/102538361/e682ae72-b2b5-4c0a-8e19-3c5ec8005445">


##### Documentation #####
<img width="802" alt="Screenshot 2023-12-11 at 5 13 02 PM" src="https://github.com/codeandtheory/ycalendarpicker-ios/assets/102538361/2fcc3fca-d028-42c6-9641-563c0eeb2cc6">

